### PR TITLE
Update find command to allow more fields

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -1,10 +1,19 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.Person;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -14,14 +23,19 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons based off "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Parameters: "
+            + "[" + PREFIX_NAME + "NAME] "
+            + "[" + PREFIX_PHONE + "PHONE] "
+            + "[" + PREFIX_EMAIL + "EMAIL] "
+            + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final Predicate<Person> predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(Predicate<Person> predicate) {
         this.predicate = predicate;
     }
 
@@ -40,3 +54,4 @@ public class FindCommand extends Command {
                 && predicate.equals(((FindCommand) other).predicate)); // state check
     }
 }
+

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -11,8 +11,6 @@ import java.util.function.Predicate;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.person.AddressContainsKeywordsPredicate;
-import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -1,12 +1,22 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.AddressContainsKeywordsPredicate;
+import seedu.address.model.person.AlwaysTruePredicate;
+import seedu.address.model.person.EmailContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.PhoneContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -21,13 +31,44 @@ public class FindCommandParser implements Parser<FindCommand> {
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
+            return new FindCommand(new AlwaysTruePredicate());
+        }
+
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(
+                        args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+                        PREFIX_ADDRESS, PREFIX_TAG);
+
+        if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
+            String noPrefixArgs = argMultimap.getValue(PREFIX_NAME).get();
+            String[] nameKeywords = noPrefixArgs.split("\\s+");
+            return new FindCommand(
+                    new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        } else if (argMultimap.getValue(PREFIX_PHONE).isPresent()) {
+            String noPrefixArgs = argMultimap.getValue(PREFIX_PHONE).get();
+            String[] phoneKeywords = noPrefixArgs.split("\\s+");
+            return new FindCommand(
+                    new PhoneContainsKeywordsPredicate(Arrays.asList(phoneKeywords)));
+        } else if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
+            String noPrefixArgs = argMultimap.getValue(PREFIX_ADDRESS).get();
+            String[] addressKeywords = noPrefixArgs.split("\\s+");
+            return new FindCommand(
+                    new AddressContainsKeywordsPredicate(Arrays.asList(addressKeywords)));
+        } else if (argMultimap.getValue(PREFIX_EMAIL).isPresent()) {
+            String noPrefixArgs = argMultimap.getValue(PREFIX_EMAIL).get();
+            String[] emailKeywords = noPrefixArgs.split("\\s+");
+            return new FindCommand(
+                    new EmailContainsKeywordsPredicate(Arrays.asList(emailKeywords)));
+        } else if (argMultimap.getValue(PREFIX_TAG).isPresent()) {
+            String noPrefixArgs = argMultimap.getValue(PREFIX_TAG).get();
+            String[] tagKeywords = noPrefixArgs.split("\\s+");
+            return new FindCommand(
+                    new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+        } else {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
-
-        String[] nameKeywords = trimmedArgs.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
     }
 
 }
+

--- a/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/AddressContainsKeywordsPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Address} matches any of the keywords given.
+ */
+public class AddressContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public AddressContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof AddressContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((AddressContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}
+

--- a/src/main/java/seedu/address/model/person/AlwaysTruePredicate.java
+++ b/src/main/java/seedu/address/model/person/AlwaysTruePredicate.java
@@ -2,6 +2,9 @@ package seedu.address.model.person;
 
 import java.util.function.Predicate;
 
+/**
+ * Returns true for any {@code Person} and keyword given.
+ */
 public class AlwaysTruePredicate implements Predicate<Person> {
 
     @Override

--- a/src/main/java/seedu/address/model/person/AlwaysTruePredicate.java
+++ b/src/main/java/seedu/address/model/person/AlwaysTruePredicate.java
@@ -1,0 +1,13 @@
+package seedu.address.model.person;
+
+import java.util.function.Predicate;
+
+public class AlwaysTruePredicate implements Predicate<Person> {
+
+    @Override
+    public boolean test(Person person) {
+        return true;
+    }
+
+}
+

--- a/src/main/java/seedu/address/model/person/AlwaysTruePredicate.java
+++ b/src/main/java/seedu/address/model/person/AlwaysTruePredicate.java
@@ -12,5 +12,11 @@ public class AlwaysTruePredicate implements Predicate<Person> {
         return true;
     }
 
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || other instanceof AlwaysTruePredicate; // instanceof handles nulls
+    }
+
 }
 

--- a/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/EmailContainsKeywordsPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Email} matches any of the keywords given.
+ */
+public class EmailContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public EmailContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((EmailContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PhoneContainsKeywordsPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+
+/**
+ * Tests that a {@code Person}'s {@code Phone} matches any of the keywords given.
+ */
+public class PhoneContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public PhoneContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getPhone().value, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PhoneContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((PhoneContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}
+

--- a/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TagContainsKeywordsPredicate.java
@@ -1,0 +1,40 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Tests that a {@code Person}'s {@code Tag} matches any of the keywords given.
+ */
+public class TagContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TagContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        Set<Tag> tagSet = person.getTags();
+        String tags = "";
+        for (Tag tag : tagSet) {
+            tags += tag.tagName;
+            tags += " ";
+        }
+        final String finalTags = tags.trim();
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(finalTags, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TagContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TagContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -72,7 +73,7 @@ public class AddressBookParserTest {
     public void parseCommand_find() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + PREFIX_NAME + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -9,6 +10,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.model.person.AlwaysTruePredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
@@ -16,19 +18,21 @@ public class FindCommandParserTest {
     private FindCommandParser parser = new FindCommandParser();
 
     @Test
-    public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    public void parse_emptyArg_returnsAllContacts() {
+        FindCommand expectedFindCommand = new FindCommand(new AlwaysTruePredicate());
+        assertParseSuccess(parser, "", expectedFindCommand);
     }
 
     @Test
     public void parse_validArgs_returnsFindCommand() {
-        // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
-        assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Amy", "Bee")));
+        assertParseSuccess(parser, NAME_DESC_AMY, expectedFindCommand);
+    }
 
-        // multiple whitespaces between keywords
-        assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    @Test
+    public void parse_invalidPrefix_throwsParseException() {
+        assertParseFailure(parser, " /g", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
 
 }


### PR DESCRIPTION
Closes #15 

## FindCommand

Logic and Parser Components:
- `FindCommand` - Update to allow searching by name, phone, address, email, and tag fields. Modified to return all contacts in the list if no parameters are passed.
- `FindCommandParser` - Modified to change input format to `find [n/KEYWORD, t/TAG, b/BIRTHDAY]`
- Added new Predicate classes for each field

Testing:
- Update testing for finding by name, and no user input

Not done:
- Increase test coverage for other fields (tag, birthday, email, phone)