### PR TITLE
Modify UI to include a center panel

### DIFF
--- a/src/main/java/seedu/address/ui/CenterPanel.java
+++ b/src/main/java/seedu/address/ui/CenterPanel.java
@@ -1,0 +1,31 @@
+package seedu.address.ui;
+
+import java.util.logging.Logger;
+
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import seedu.address.commons.core.LogsCenter;
+
+/**
+ * The Center Panel. The left half is used to display the PersonListPanel
+ * while the right half is used to display the ReminderListPanel.
+ */
+public class CenterPanel extends UiPart<Region> {
+    private static final String FXML = "CenterPanel.fxml";
+    private final Logger logger = LogsCenter.getLogger(ReminderListPanel.class);
+
+    @javafx.fxml.FXML
+    private StackPane personListPanelPlaceholder;
+
+    @javafx.fxml.FXML
+    private StackPane reminderListPanelPlaceholder;
+
+    /**
+     * Creates a {@code ReminderListPanel} with the given {@code ObservableList}.
+     */
+    public CenterPanel(PersonListPanel personListPanel, ReminderListPanel reminderListPanel) {
+        super(FXML);
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        reminderListPanelPlaceholder.getChildren().add(reminderListPanel.getRoot());
+    }
+}

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -35,6 +35,8 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private ReminderWindow reminderWindow;
+    private ReminderListPanel reminderListPanel;
+    private CenterPanel centerPanel;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -43,7 +45,7 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane personListPanelPlaceholder;
+    private StackPane centerPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -114,7 +116,9 @@ public class MainWindow extends UiPart<Stage> {
         reminderWindow = new ReminderWindow(logic.getAddressBook().getPersonList());
 
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
-        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        reminderListPanel = new ReminderListPanel(logic.getAddressBook().getPersonList());
+        centerPanel = new CenterPanel(personListPanel, reminderListPanel);
+        centerPanelPlaceholder.getChildren().add(centerPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());

--- a/src/main/resources/view/CenterPanel.fxml
+++ b/src/main/resources/view/CenterPanel.fxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
+
+<HBox xmlns="http://javafx.com/javafx/18" xmlns:fx="http://javafx.com/fxml/1">
+   <children>
+      <StackPane fx:id="personListPanelPlaceholder" minWidth="100.0" HBox.hgrow="ALWAYS" />
+      <StackPane fx:id="reminderListPanelPlaceholder" minWidth="105.0" HBox.hgrow="ALWAYS" />
+   </children>
+</HBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -33,11 +33,11 @@
           </Menu>
         </MenuBar>
 
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+        <VBox fx:id="centerPanel" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
             <padding>
                 <Insets top="10" right="10" bottom="10" left="10" />
             </padding>
-            <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+            <StackPane fx:id="centerPanelPlaceholder" VBox.vgrow="ALWAYS"/>
         </VBox>
 
         <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"


### PR DESCRIPTION
## CenterPanel UI

Added the Center Panel to the UI to display the person list on the left half and the reminder list on the right half.

UI Components:
* `MainWindow` - Modified, to handle displaying the `CenterPanel` instead of just the `PersonListPanel` component on the GUI.
* `CenterPanel` - Added, the component used to display both the `PersonListPanel` and the `ReminderListPanel` on the GUI.
* `MainWindow.fxml` - Modified, to change the fx tag for the `personListPanelPlaceholder` to `centerPanelPlaceholder`.
* `CenterPanel.fxml` - Added, corresponds to what to display on the GUI for `CenterPanel` component.