### PR TITLE
Update UG for Find command and fix bug for parsing multiple prefixes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -56,7 +56,7 @@ Friendnancial is a **desktop application, optimized for use by financial advisor
   e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
 
 * Items in square brackets are optional.<br>
-  e.g `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
+  e.g. `n/NAME [t/TAG]` can be used as `n/John Doe t/friend` or as `n/John Doe`.
 
 * Items with `…`​ after them can be used multiple times including zero times.<br>
   e.g. `[t/TAG]…​` can be used as ` ` (i.e. 0 times), `t/friend`, `t/friend t/family` etc.
@@ -129,23 +129,27 @@ Examples:
 
 Finds persons by the given keywords.
 
-Format: `find [n/KEYWORD] [t/TAG] [b/BIRTHDAY]`
+Format: `find [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG] [b/BIRTHDAY]`
 
-* Entering `find` with no keywords after will simply return the list of all contacts.
-* Users can filter persons by any field by using `[letter]/[KEYWORD]`. e.g.
-`find n/john` returns persons whose name fields contain the keyword, while `find t/TAG`
-returns persons whose tag fields contain the specified tag.
-* The search is case-insensitive. e.g `hans` will match `Hans`
-* The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
-* Only the name is searched.
-* Only full words will be matched e.g. `Han` will not match `Hans`
-* Persons matching at least one keyword will be returned (i.e. `OR` search).
-  e.g. `Hans Bo` will return `Hans Gruber`, `Bo Yang`
+* Entering `find` without any prefixes will display all contacts.
+* Users can only find contacts by one field at each time. <br>e.g. `find n/Alex a/Geylang` will result in an error. 
+* The keywords are case-insensitive. <br>e.g. `hans` will match `Hans`
+* The order of the keywords does not matter. <br>e.g. `Hans Bo` will match `Bo Hans`
+* Only full words will be matched <br>e.g. `Han` will not match `Hans`
+<br>e.g. `alex` will not match `alexyeoh@example.com`
+* Any contact matching at least one keyword will be returned.
+  e.g. `find n/Hans Bo` will display contacts named `Hans Gruber` and `Bo Yang`
+
+<div markdown="span" class="alert alert-warning">:warning: **Note:**
+When finding a contact based off address, all non-alphanumeric characters (excluding # and -) will be ignored
+</div>
 
 Examples:
-* `find n/John` returns `john` and `John Doe`
-* `find n/alex david` returns `Alex Yeoh`, `David Li`<br>
-  ![result for 'find alex david'](images/findAlexDavidResultUpdated.png)
+* `find n/John` displays contacts named `john` and `John Doe`
+* `find n/alex david` returns `Alex Yeoh`, `David Li`
+* `find a/gardens` will display a contact with the address `Serangoon Gardens, #06-40`
+* `find a/#06-40` will display a contact with the address `Serangoon Gardens, #06-40`
+* `find a/06` or `find a/06-40` will not display a contact with the address `Serangoon Gardens, #06-40`
 
 ### Deleting a person : `delete`
 
@@ -174,19 +178,18 @@ Format: `clear`
 
 ### Adding a reminder : `remind`
 
-Adds a reminder which is tied to a specified contact.
+Adds a reminder for a specified contact.
 
 Format: `remind INDEX r/REMINDER d/DATE`
 
-* Adds a reminder to the person at the specified `INDEX` with the `REMINDER` and `DATE`.
+* Adds a reminder for the contact at the specified `INDEX` with the `REMINDER` and `DATE`.
 * The index refers to the index number shown in the displayed person list.
 * The index **must be a positive integer** 1, 2, 3, ...
 * The date **must be in the format of** `DD-MM-YYYY`.
 
 
 Examples:
-* `remind 2 r/update client information d/20-10-2022` adds a reminder to the 2nd person in the address book.
-* `find Betsy` followed by `remind 1 r/buy gift d/25-10-2022` adds a reminder linked to the 1st person in the result of the `find` command, which would be `Betsy`.
+* `remind 2 r/update client information d/20-10-2022` adds a reminder to the 2nd contact in the currently displayed list.
 
 ### Deleting a reminder : `deleteR`
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -28,7 +29,8 @@ public class FindCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]"
+            + "[" + PREFIX_BIRTHDAY + "BIRTHDAY]\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie";
 
     private final Predicate<Person> predicate;

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -33,7 +33,7 @@ public class FindCommandParser implements Parser<FindCommand> {
             + "the find command can only contain one prefix";
 
     private static final Prefix[] validPrefixArray = new Prefix[] {PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-            PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
+        PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -29,6 +29,12 @@ public class FindCommandParser implements Parser<FindCommand> {
     public static final String MESSAGE_NO_ALPHANUMERIC = "Parameters for "
             + "the find command must contain an alphanumeric character";
 
+    public static final String MESSAGE_MULTIPLE_PREFIX = "Parameters for "
+            + "the find command can only contain one prefix";
+
+    public static final Prefix[] validPrefixArray = new Prefix[]{PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+            PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
+
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
@@ -44,6 +50,8 @@ public class FindCommandParser implements Parser<FindCommand> {
                 ArgumentTokenizer.tokenize(
                         args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
                         PREFIX_ADDRESS, PREFIX_BIRTHDAY, PREFIX_TAG);
+
+        checkMultiplePrefix(argMultimap);
 
         if (argMultimap.getValue(PREFIX_NAME).isPresent()) {
             String noPrefixArgs = argMultimap.getValue(PREFIX_NAME).get();
@@ -122,6 +130,22 @@ public class FindCommandParser implements Parser<FindCommand> {
             birthdayKeywords[i] = birthday.toString();
         }
         return birthdayKeywords;
+    }
+
+    /**
+     * Checks the given {@code String} of arguments for multiple prefixes.
+     * @throws ParseException if there are more than 1 valid prefixes present.
+     */
+    public static void checkMultiplePrefix(ArgumentMultimap argMultimap) throws ParseException {
+        int prefixCount = 0;
+        for (Prefix pfx : validPrefixArray) {
+            if (argMultimap.getValue(pfx).isPresent()) {
+                prefixCount++;
+            }
+        }
+        if (prefixCount > 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_MULTIPLE_PREFIX));
+        }
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -32,8 +32,8 @@ public class FindCommandParser implements Parser<FindCommand> {
     public static final String MESSAGE_MULTIPLE_PREFIX = "Parameters for "
             + "the find command can only contain one prefix";
 
-    public static final Prefix[] validPrefixArray = new Prefix[]{PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
-            PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
+    private static final Prefix[] validPrefixArray = new Prefix[]{
+            PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -32,8 +32,8 @@ public class FindCommandParser implements Parser<FindCommand> {
     public static final String MESSAGE_MULTIPLE_PREFIX = "Parameters for "
             + "the find command can only contain one prefix";
 
-    private static final Prefix[] validPrefixArray = new Prefix[]{
-            PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
+    private static final Prefix[] validPrefixArray = new Prefix[] {PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL,
+            PREFIX_ADDRESS, PREFIX_TAG, PREFIX_BIRTHDAY};
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand


### PR DESCRIPTION
Fix bugs such that a parse exception is thrown when multiple prefixes are inputted.

Updated UG to only allow one prefix to be passed into the `find` command.
Closes #148 

Updated UG to include all valid prefixes for the `find` command.
Closes #126
Closes #142 
Closes #156 

Fixed typo under the "Adding a reminder" section of UG.
Closes #132 