### PR TITLE
Fix bug for empty reminder field

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ReminderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ReminderCommand.java
@@ -21,6 +21,7 @@ public class ReminderCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 r/update client information d/20-10-2022";
     public static final String MESSAGE_DATE_CONSTRAINTS = "Date should be in the format 'D-MM-YYYY'";
     public static final String MESSAGE_INVALID_DATE = "The date provided is invalid!";
+    public static final String MESSAGE_EMPTY_REMINDER = "The reminder should not be empty!";
 
     public static final String MESSAGE_ADD_REMINDER_SUCCESS = "Added reminder to Person: %1$s";
     public static final String MESSAGE_DELETE_REMINDER_SUCCESS = "Removed reminder from Person: %1$s";

--- a/src/main/java/seedu/address/logic/parser/ReminderCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ReminderCommandParser.java
@@ -44,6 +44,11 @@ public class ReminderCommandParser {
         String task = argMultimap.getValue(PREFIX_REMINDER).orElse("");
         String date = argMultimap.getValue(PREFIX_DATE).orElse("");
 
+        if (task.isBlank()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    ReminderCommand.MESSAGE_EMPTY_REMINDER));
+        }
+
         try {
             LocalDate.parse(date, DateTimeFormatter.ofPattern(DATE_FORMAT_PATTERN)
                     .withResolverStyle(ResolverStyle.STRICT));


### PR DESCRIPTION
Update `ReminderCommandParser` to throw a `ParseException` when the reminder field is left empty.

Closes #152 
Closes #145